### PR TITLE
Fix typo

### DIFF
--- a/src/lib/components/About.svelte
+++ b/src/lib/components/About.svelte
@@ -9,7 +9,7 @@
         <h1 class="text-blue-whale text-2xl md:text-5xl font-bold">About SNiC</h1>
         <div class="flex w-full flex-col content-between max-h-fit lg:max-h-[70vh] flex-wrap gap-4 text-blue-whale">
         <article class="lg:w-1/2">
-            SNiC, Stichting Nationaal informatica Congress (which can be translated as the Foundation National
+            SNiC, Stichting Nationaal informatica Congres (which can be translated as the Foundation National
             Informatics
             Congress), was established in December 2004. 10 study associations from cities in the Netherlands are
             affiliated.

--- a/src/lib/components/Footer.svelte
+++ b/src/lib/components/Footer.svelte
@@ -8,7 +8,7 @@
     <div class="container justify-between items-center px-8 py-4 gap-8 flex-col md:flex-row">
         <div id="copyright" class="flex flex-col order-3 md:order-none md:w-80">
             <p><i class="fa-regular fa-copyright"></i> 2024 Copyright</p>
-            <a href="https://snic.nl">Stichting Nationaal Informatica Congress</a>
+            <a href="https://snic.nl">Stichting Nationaal Informatica Congres</a>
             </div>
     
         <div id="logo" class="order-1 md:order-none">


### PR DESCRIPTION
The full name of SNiC was incorrect, it's Congres